### PR TITLE
Docs/contribution coc

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in JourNULL‑CodeXCaliber‑25 a harassment‑free experience for everyone, regardless of background or identity.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language  
+- Being respectful of differing viewpoints and experiences  
+- Showing empathy toward other community members  
+
+Examples of unacceptable behavior by participants include:
+- Harassing language or imagery  
+- Trolling, insulting/derogatory comments, and personal attacks  
+- Publishing others’ private information  
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying standards and enforcing the Code of Conduct. They have the right to remove, edit, or reject comments, commits, issues, pull requests, and other contributions that do not align with this Code of Conduct.
+
+## Scope
+This Code of Conduct applies both within project spaces and in public channels when an individual is representing the project.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at **[your-email@example.com]**. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1][covenant].
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to JourNULL‑CodeXCaliber‑25
 
-Thank you for helping improve this project! Whether you’re fixing bugs, proposing features, or enhancing docs, your efforts are welcome. Please follow these guidelines to make the process smooth for everyone.
+Thank you for helping make this project better! Whether you’re fixing bugs, proposing new features, improving documentation, or just giving feedback, your contributions are welcome and appreciated.
 
 ---
 
@@ -18,39 +18,87 @@ Thank you for helping improve this project! Whether you’re fixing bugs, propos
 
 ## Getting Started
 
-1. **Fork** this repository  
+1. **Fork** this repository on GitHub  
 2. **Clone** your fork locally  
-3. **Create** a branch for your work (`feature/xyz` or `fix/abc`)  
-4. **Write** clear, focused commits  
-5. **Push** your branch and open a PR  
+3. **Create** a branch for your work:  
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```  
+4. **Make** your changes in small, focused commits  
+5. **Push** your branch to your fork  
+6. **Open** a Pull Request against `main` in the upstream repo  
 
 ---
 
 ## Development Workflow
 
-- Use descriptive branch names:  
+- Use clear, descriptive branch names:  
   - `feature/login-form`  
   - `fix/navbar-overlap`  
-- Keep changes scoped to one issue  
-- Run existing tests (if any) and add new ones as needed  
-- Follow existing code style and formatting  
+- Scope each branch to a single issue or feature  
+- Adhere to the project’s existing code style and formatting  
+- Run any existing tests and add new ones if appropriate  
 
 ---
 
 ## Local Setup
 
 **Prerequisites**  
-- Node.js ≥ 14.x  
-- npm or Yarn
+- Node.js version 14 or higher  
+- npm or Yarn  
 
-**Steps**  
+**Installation & Run**  
 ```bash
 # 1. Clone your fork
-git clone https://github.com/<your-user>/JourNULL-CodeXCaliber-25.git
+git clone https://github.com/<your-username>/JourNULL-CodeXCaliber-25.git
 cd JourNULL-CodeXCaliber-25
 
 # 2. Install dependencies
-npm install   # or yarn install
+npm install       # or yarn install
 
 # 3. Start the development server
-npm start     # or yarn start
+npm start         # or yarn start
+```
+
+---
+
+## Submitting Changes
+
+1. Push your branch to GitHub.  
+2. Open a Pull Request against `main`.  
+3. In your PR description:
+   - Reference the related issue (e.g., “Closes #13”)  
+   - Summarize your changes in bullet points  
+   - Include any relevant screenshots or testing steps  
+4. Wait for review and address feedback as needed.  
+
+---
+
+## Reporting Issues
+
+When opening an issue, please include:
+
+- A concise **title** and clear **description**  
+- Steps to **reproduce** the problem  
+- **Expected** vs. **actual** behavior  
+- Screenshots, logs, or error messages if applicable  
+
+---
+
+## Code of Conduct
+
+This project is governed by the [Contributor Covenant v2.1][covenant].  
+By participating, you agree to abide by its terms.  
+Please read the full text in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+---
+
+## Additional Resources
+
+- [Project README](README.md)  
+- [Style Guide](docs/STYLE_GUIDE.md)  
+- Join our Discord: `#support`  
+- Browse issues labeled [`help wanted`](https://github.com/GDSC-IIITN/JourNULL-CodeXCaliber-25/labels/help%20wanted)  
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to JourNULL‑CodeXCaliber‑25
+
+Thank you for helping improve this project! Whether you’re fixing bugs, proposing features, or enhancing docs, your efforts are welcome. Please follow these guidelines to make the process smooth for everyone.
+
+---
+
+## Table of Contents
+
+1. [Getting Started](#getting-started)  
+2. [Development Workflow](#development-workflow)  
+3. [Local Setup](#local-setup)  
+4. [Submitting Changes](#submitting-changes)  
+5. [Reporting Issues](#reporting-issues)  
+6. [Code of Conduct](#code-of-conduct)  
+7. [Additional Resources](#additional-resources)  
+
+---
+
+## Getting Started
+
+1. **Fork** this repository  
+2. **Clone** your fork locally  
+3. **Create** a branch for your work (`feature/xyz` or `fix/abc`)  
+4. **Write** clear, focused commits  
+5. **Push** your branch and open a PR  
+
+---
+
+## Development Workflow
+
+- Use descriptive branch names:  
+  - `feature/login-form`  
+  - `fix/navbar-overlap`  
+- Keep changes scoped to one issue  
+- Run existing tests (if any) and add new ones as needed  
+- Follow existing code style and formatting  
+
+---
+
+## Local Setup
+
+**Prerequisites**  
+- Node.js ≥ 14.x  
+- npm or Yarn
+
+**Steps**  
+```bash
+# 1. Clone your fork
+git clone https://github.com/<your-user>/JourNULL-CodeXCaliber-25.git
+cd JourNULL-CodeXCaliber-25
+
+# 2. Install dependencies
+npm install   # or yarn install
+
+# 3. Start the development server
+npm start     # or yarn start

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,11 @@ Thank you for helping make this project better! Whether you’re fixing bugs, pr
 
 ## Local Setup
 
-**Prerequisites**  
-- Node.js version 14 or higher  
-- npm or Yarn  
+**Prerequisites**
+
+- pnpm (preferred package manager)
+- Bun (runtime for backend)
+- Node.js version 16 or higher 
 
 **Installation & Run**  
 ```bash
@@ -53,13 +55,15 @@ Thank you for helping make this project better! Whether you’re fixing bugs, pr
 git clone https://github.com/<your-username>/JourNULL-CodeXCaliber-25.git
 cd JourNULL-CodeXCaliber-25
 
-# 2. Install dependencies
-npm install       # or yarn install
+# 2. Install dependencies using pnpm
+pnpm install
 
 # 3. Start the development server
-npm start         # or yarn start
-```
+pnpm start
 
+# 4. For backend, ensure Bun is installed and run using:
+bun dev
+```
 ---
 
 ## Submitting Changes
@@ -101,4 +105,3 @@ Please read the full text in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 - Browse issues labeled [`help wanted`](https://github.com/GDSC-IIITN/JourNULL-CodeXCaliber-25/labels/help%20wanted)  
 
 [covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
-```


### PR DESCRIPTION
**Closes** #13

---

### What’s Changed
- Added **CONTRIBUTING.md** at project root  
  - Intro, TOC, workflow, local setup, issue/PR guide, CoC link  
- Added **CODE_OF_CONDUCT.md** (Contributor Covenant v2.1) 
- Renamed Branch to docs/contribution-coc

---

### Testing Steps
1. `git fetch origin add-contributing-guidelines`  
   `git checkout add-contributing-guidelines`  
2. Preview **CONTRIBUTING.md** and **CODE_OF_CONDUCT.md** in GitHub’s “Preview” tab  
3. Click every TOC link and verify they jump to the right section  